### PR TITLE
Fixed backup file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+# User-specific files
+*.suo
+
+/PC interface/Project/ArduDebug/ArdudebugInterface/bin
+/PC interface/Project/ArduDebug/ArdudebugInterface/obj
+/PC interface/Project/ArduDebug/GraphDisplay/GraphLib/bin
+/PC interface/Project/ArduDebug/GraphDisplay/GraphLib/obj

--- a/PC interface/Project/ArduDebug/ArdudebugInterface/clsParser.cs
+++ b/PC interface/Project/ArduDebug/ArdudebugInterface/clsParser.cs
@@ -22,9 +22,9 @@ namespace ArduDebugInterface
             {
                 string FolderPref = Path.GetDirectoryName(clsConfiguration.ArduinoPrefFile);
 
-                if (!File.Exists(FolderPref + "\\Preference.backup.txt"))
+                if (!File.Exists(FolderPref + "\\Preferences.backup.txt"))
                 {
-                    File.Copy(clsConfiguration.ArduinoPrefFile, FolderPref + "\\Preference.backup.txt");
+                    File.Copy(clsConfiguration.ArduinoPrefFile, FolderPref + "\\Preferences.backup.txt");
                 }
 
                 string[] lines = File.ReadAllLines(clsConfiguration.ArduinoPrefFile);


### PR DESCRIPTION
I think "Preferences.backup.txt" is appropriate.
Arduino Preferences file name is "preferences.txt"
